### PR TITLE
fix: 一些样式优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ node_modules/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+pnpm-lock.yaml

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -1,32 +1,54 @@
 <template>
-    <!-- 必须包裹容器 -->
-    <div class="vp-doc">
-        <Content />
+  <!-- 必须包裹容器 -->
+  <div class="vp-doc">
+    <div class="header_redline"></div>
+    <!-- 如果是首页就不渲染子页面头部 -->
+    <ChildHeader v-if="$frontmatter.layout !== 'home'" />
+    <div class="body_content">
+      <Content />
     </div>
+    <!-- 如果是首页则底部始终置底 -->
+    <ChildFooter
+      :class="{'footer_always_in_bottom': $frontmatter.layout === 'home' ? true : false}"
+    />
+  </div>
 </template>
+
+<script setup>
+import ChildHeader from "/components/ChildHeader.vue";
+import ChildFooter from "/components/ChildFooter.vue";
+</script>
 
 <style type="text/css">
 html,
 body {
-    height: 100%;
-    margin: 0;
+  height: 100%;
+  margin: 0;
 }
 
 .body_content {
-    display: block;
-    clear: both;
-    width: auto;
-    max-width: 1200px;
-    height: auto;
-    overflow: hidden;
-    margin: 0 auto;
+  display: block;
+  clear: both;
+  width: auto;
+  max-width: 1200px;
+  height: auto;
+  overflow: hidden;
+  margin: 0 auto;
+}
+
+.footer_always_in_bottom {
+  position: fixed;
+  z-index: 2;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 @media (max-width: 1280px) {
-    .body_content {
-        width: 100%;
-        max-width: 100%;
-        padding: 0px 30px;
-    }
+  .body_content {
+    width: 100%;
+    max-width: 100%;
+    padding: 0px 30px;
+  }
 }
 </style>

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,3 +1,12 @@
 .vp-doc div[class*='language-'], .vp-block {
   margin: 16px 0px
 }
+
+.header_redline {
+  display: block;
+  clear: both;
+  width: 100%;
+  height: 25px;
+  overflow: hidden;
+  background-color: #e60013;
+}

--- a/components/ChildHeader.vue
+++ b/components/ChildHeader.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="header_box">
-    <div class="header_redline"></div>
     <div class="page_body">
       <div class="main_title">
-        <h1><slot name="pageTitle"></slot></h1>
-        <h4><slot name="pageSubTitle"></slot></h4>
+        <!-- <h1><slot name="pageTitle"></slot></h1>
+        <h4><slot name="pageSubTitle"></slot></h4> -->
+        <h1>{{ $frontmatter.pageTitle }}</h1>
+        <h4>{{ $frontmatter.pageSubTitle }}</h4>
       </div>
       <div class="brand_mark">
         <img src="/images/brand_mark.webp" />
@@ -18,7 +19,6 @@
       <span class="name">返回上级</span>
     </a>
   </div>
-
   <BackToTop />
 </template>
 
@@ -48,15 +48,6 @@ body {
   background-color: #FFF;
   border-bottom: 5px solid red;
   box-sizing: border-box;
-}
-
-.header_redline {
-  display: block;
-  clear: both;
-  width: 100%;
-  height: 25px;
-  overflow: hidden;
-  background-color: #e60013;
 }
 
 .page_body {

--- a/components/Index.vue
+++ b/components/Index.vue
@@ -1,5 +1,4 @@
 <template>
-  <div class="header_redline"></div>
   <div class="home_body">
     <div class="main_logo">
       <img src="/images/logo.webp" />
@@ -97,21 +96,6 @@
       </div>
     </div>
   </div>
-
-  <div class="footer_info">
-    <div class="footer_link">
-      <a href="https://github.com/loongson-community/loongfans" target="_blank">站点源码</a>
-      <span>|</span>
-      <a href="https://github.com/loongson-community/loongfans/issues/new" target="_blank">报告问题</a>
-      <span>|</span>
-      <a href="/pages/about">关于龙芯爱好者社区</a>
-    </div>
-
-    <div class="copyright_info">
-      <span>版权所有 &copy; 2024-{{ copyrightYear }} 龙芯爱好者社区</span>
-      <a href="https://beian.miit.gov.cn" target="_blank">鄂ICP备2022017735号-12</a>
-    </div>
-  </div>
 </template>
 
 <script setup>
@@ -126,21 +110,12 @@ const forceRefresh = (url) => {
 
 <style>
 body {
-  background: url("/images/bg_body.webp") no-repeat top center;
+  /* background: url("/images/bg_body.webp") no-repeat top center; */
   background-size: cover;
 }
 </style>
 
 <style scoped>
-.header_redline {
-  display: block;
-  clear: both;
-  width: 100%;
-  height: 25px;
-  overflow: hidden;
-  background-color: #e60013;
-}
-
 .home_body {
   display: flex;
   justify-content: space-between;
@@ -282,50 +257,6 @@ body {
 }
 
 /*站点导航清单-结束*/
-
-.footer_info {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 20px;
-  clear: both;
-  width: auto;
-  max-width: 1200px;
-  height: 50px;
-  line-height: 50px;
-  overflow: hidden;
-  margin: 0px auto;
-  position: fixed;
-  z-index: 2;
-  left: 0;
-  right: 0;
-  bottom: 0;
-}
-
-.footer_link,
-.copyright_info {
-  flex-shrink: 0;
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 10px;
-  width: auto;
-  height: 40px;
-  line-height: 40px;
-  overflow: hidden;
-  font-size: 16px;
-  color: #000000;
-}
-
-.footer_info a {
-  font-size: 16px;
-  color: #000000;
-  text-decoration: none;
-}
-
-.footer_info a:hover {
-  color: #e60013;
-}
 
 /*响应式处理-开始*/
 @media (max-width: 1200px) {

--- a/pages/about.md
+++ b/pages/about.md
@@ -2,24 +2,12 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 关于社区
+pageSubTitle: 东方神秘第三方社区
 ---
 
-<ChildHeader>
-<template #pageTitle>关于社区</template>
-<template #pageSubTitle>东方神秘第三方社区</template>
-</ChildHeader>
-
-<div class="body_content">
 
 ![](/public/images/logo_about.webp)
 
 龙芯爱好者社区创立于 2024 年 10 月 24 日程序员节，是一个由第三方爱好者、行业人员与学生组成的，致力于龙芯（龙架构）软硬件生态建设的互联网社区。
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/biweekly.md
+++ b/pages/biweekly.md
@@ -2,14 +2,10 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 龙架构双周会
+pageSubTitle: 属于龙芯社区开发者和爱好者的线上 + 线下聚会
 ---
 
-<ChildHeader>
-<template #pageTitle>龙架构双周会</template>
-<template #pageSubTitle>属于龙芯社区开发者和爱好者的线上 + 线下聚会</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙架构双周会是由龙芯爱好者组织的社区会议，会议议程包括针对上游及各 Linux 发行版及其他系统项目的开发进展报告、社区事务报告，以及贡献者讨论及问答环节。
 
@@ -25,11 +21,3 @@ returnLink: /
 双周会幻灯片将在**会前停止收集**，希望在双周会发言提问的同学请在此时间前填写编辑完成（如需编辑权限请通过金山文档申请）。
 :::
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices.md
+++ b/pages/devices.md
@@ -2,14 +2,10 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 产品规格数据库
+pageSubTitle: 规格参数、特色配置及已知问题一览
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>规格参数、特色配置及已知问题一览</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯的处理器和板卡型号众多，但一般以处理器 + 主板（板 U）捆绑的模式销售。本页面用于记录和呈现所有已知的龙芯板 U 组合，以及笔记本、服务器整机信息。
 
@@ -71,11 +67,3 @@ returnLink: /
 - [正点原子 2K0300 开发板](/pages/devices/alientek-2k0300-evb)
 - [中科云久久派](/pages/devices/ctcisz-foreverpi)
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/alientek-2k0300-evb.md
+++ b/pages/devices/alientek-2k0300-evb.md
@@ -1,14 +1,9 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 正点原子 2K0300 开发板
 ---
-
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>正点原子 2K0300 开发板</template>
-</ChildHeader>
-
-<div class="body_content">
 
 正点原子 2K0300 开发板是一款基于 2K0300 平台设计的开发板。
 
@@ -36,11 +31,3 @@ returnLink: /pages/devices
 ![](/public/images/devices/alientek-2k0300-evb-2.webp)
 来源：正点原子
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/asus-xc-ls3a6m.md
+++ b/pages/devices/asus-xc-ls3a6m.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 华硕 XC-LS3A6M
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>华硕 XC-LS3A6M</template>
-</ChildHeader>
-
-<div class="body_content">
 
 华硕 XC-LS3A6M 是由华硕推出的，基于 3A6000-HV 平台设计的 DTX (203×244mm) 台式机主板。
 
@@ -61,11 +57,4 @@ returnLink: /pages/devices
 ![](/public/images/devices/asus-xc-ls3a6m.webp)
 来源：[AliExpress 网店](https://aliexpress.com/item/1005006592333955.html)
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/ctcisz-3a6000-nuc.md
+++ b/pages/devices/ctcisz-3a6000-nuc.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 中科云 3A6000 小主机
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>中科云 3A6000 小主机</template>
-</ChildHeader>
-
-<div class="body_content">
 
 中科云 3A6000 小主机是一款类似 Intel NUC 规格的小型台式机，搭载 3A6000-HV 处理器，并提供双 HDMI 输出及双千兆 (GbE) 以太网口。
 
@@ -38,11 +34,5 @@ returnLink: /pages/devices
 [![](/public/images/devices/ctcisz-3a6000-nuc.thumbnail.webp)](/public/images/devices/ctcisz-3a6000-nuc.webp)
 来源：中科云
 
-</div>
 
-<ChildFooter />
 
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/ctcisz-3b6000m-nuc.md
+++ b/pages/devices/ctcisz-3b6000m-nuc.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 中科云 3B6000M 小主机
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>中科云 3B6000M 小主机</template>
-</ChildHeader>
-
-<div class="body_content">
 
 中科云 3B6000M 小主机是一款类似 Intel NUC 规格的小型台式机，搭载 3B6000M 处理器，并提供双 HDMI 输出及双千兆 (GbE) 以太网口。
 
@@ -35,11 +31,4 @@ returnLink: /pages/devices
 
 （待更新）
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/ctcisz-foreverpi.md
+++ b/pages/devices/ctcisz-foreverpi.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 中科云 2K0300 久久派
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>中科云 2K0300 久久派</template>
-</ChildHeader>
-
-<div class="body_content">
 
 中科云 2K0300 久久派是由中科云推出的，基于 2K0300 平台设计的开发板。
 
@@ -54,11 +50,4 @@ returnLink: /pages/devices
 
 （待更新）
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/excelsior-nl38-n11.md
+++ b/pages/devices/excelsior-nl38-n11.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 卓怡恒通 NL38-N11
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>卓怡恒通 NL38-N11</template>
-</ChildHeader>
-
-<div class="body_content">
 
 卓怡恒通 NL38-N11 是一款基于 3A6000 处理器的 14 寸笔记本电脑，其重量约 1.4kg，搭载 2240×1400 (2.2K) 或 1920x1200 (WUXGA) 屏幕，接口较为丰富，续航约 3-4 小时。
 
@@ -62,11 +58,3 @@ Linux 内核方面，需要为 7A2000 GPIO 驱动[增加中断支持](https://gi
 ![](/public/images/devices/excelsior-nl38-n11.webp)
 来源：[卓怡恒通官网](https://eaecis.com/cp_95/962.html)
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/kaitian-n60d-g1d.md
+++ b/pages/devices/kaitian-n60d-g1d.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 联想开天 N60d-G1d
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>联想开天 N60d-G1d</template>
-</ChildHeader>
-
-<div class="body_content">
 
 联想开天 N60d-G1d 是一款基于 3A6000 处理器的 14 寸笔记本电脑，其重量约 1.5kg，搭载 1920x1200 (WUXGA) 屏幕，接口较为丰富，续航约 3-4 小时。
 
@@ -57,11 +53,3 @@ returnLink: /pages/devices
 [![](/public/images/devices/kaitian-n60d-g1d.thumbnail.webp)](/public/images/devices/kaitian-n60d-g1d.webp)
 来源：白铭骢
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-2k0300-hummingbird-evb.md
+++ b/pages/devices/loongson-2k0300-hummingbird-evb.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 2K0300 蜂鸟板
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 2K0300 蜂鸟板</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 2K0300 蜂鸟板是由龙芯中科推出的，基于 2K0300 平台设计的开发板。
 
@@ -37,11 +33,3 @@ returnLink: /pages/devices
 ![](/public/images/devices/loongson-2k0300-hummingbird-evb.webp)
 来源：龙芯中科
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-2k0300-pioneer-evb.md
+++ b/pages/devices/loongson-2k0300-pioneer-evb.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 2K0300 先锋派
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 2K0300 先锋派</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 2K0300 先锋派是由龙芯中科推出的，基于 2K0300 平台设计的开发板。
 
@@ -37,11 +33,3 @@ returnLink: /pages/devices
 ![](/public/images/devices/loongson-2k0300-pioneer-evb.webp)
 来源：龙芯中科
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-2k3000-ai-evb.md
+++ b/pages/devices/loongson-2k3000-ai-evb.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 2K3000 AI 评估板
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 2K3000 AI 评估板</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 2K3000 AI 评估板是由龙芯中科推出的，基于 2K3000-i 平台设计的开发板。
 
@@ -37,11 +33,3 @@ returnLink: /pages/devices
 ![](/public/images/devices/loongson-2k3000-ai-evb.webp)
 来源：龙芯中科
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-ac612a0-v1.1.md
+++ b/pages/devices/loongson-ac612a0-v1.1.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 AC612A0_V1.1
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 AC612A0_V1.1</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 AC612A0_V1.1 是由龙芯中科推出的，基于 3C6000/S 平台设计的 ATX (244×305mm) 台式机/服务器主板。
 
@@ -45,11 +41,4 @@ returnLink: /pages/devices
 [![](/public/images/devices/loongson-ac612a0-v1.1.thumbnail.webp)](/public/images/devices/loongson-ac612a0-v1.1.webp)
 来源：《龙芯 3C6000 单路服务器主板产品规格书 V1.0》
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-xa61200.md
+++ b/pages/devices/loongson-xa61200.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 XA61200
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 XA61200</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 XA61200 是由龙芯中科推出的，基于 3A6000-HV 平台设计的 DTX (203×244mm) 台式机主板。
 
@@ -42,11 +38,3 @@ returnLink: /pages/devices
 [![](/public/images/devices/loongson-xa61200.thumbnail.webp)](/public/images/devices/loongson-xa61200.webp)
 来源：《XA61200 主板产品使用手册 V1.1》
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-xa61201.md
+++ b/pages/devices/loongson-xa61201.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 XA61201
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 XA61201</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 XA61201 是由龙芯中科推出的，基于 3A6000-HV 平台设计的 DTX (203×244mm) 台式机主板。
 
@@ -47,11 +43,4 @@ returnLink: /pages/devices
 [![](/public/images/devices/loongson-xa61201.thumbnail.webp)](/public/images/devices/loongson-xa61201.webp)
 来源：《XA61201 主板产品使用手册 V1.0》
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-xa612a0.md
+++ b/pages/devices/loongson-xa612a0.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 XA612A0
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 XA612A0</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 XA612A0 是由龙芯中科推出的，基于 3A6000-HV 平台设计的 ATX (244×305mm) 台式机主板。
 
@@ -44,11 +40,3 @@ returnLink: /pages/devices
 [![](/public/images/devices/loongson-xa612a0.thumbnail.webp)](/public/images/devices/loongson-xa612a0.webp)
 来源：《XA612A0 主板使用手册 V1.0》
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/loongson-xb612b0-v1.1.md
+++ b/pages/devices/loongson-xb612b0-v1.1.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 龙芯 XB612B0_V1.1
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>龙芯 XB612B0_V1.1</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯 XB612B0_V1.1 是由龙芯中科推出的，基于 3B6000 平台设计的 mATX (244×244mm) 台式机主板。
 
@@ -38,11 +34,4 @@ returnLink: /pages/devices
 [![](/public/images/devices/loongson-xb612b0-v1.1.thumbnail.webp)](/public/images/devices/loongson-xb612b0-v1.1.webp)
 来源：Xi Ruoyao
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/morefine-m700s.md
+++ b/pages/devices/morefine-m700s.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: 摩方 M700S 小主机
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>摩方 M700S</template>
-</ChildHeader>
-
-<div class="body_content">
 
 摩方 M700S 是一款类似 Intel NUC 规格的小型台式机，搭载 3A6000-HV 处理器，并提供双 HDMI 输出。
 
@@ -38,11 +34,3 @@ returnLink: /pages/devices
 [![](/public/images/devices/morefine-m700s.thumbnail.webp)](/public/images/devices/morefine-m700s.webp)
 来源：[摩方官网](http://www.imorefine.com/h-pd-53.html)
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/devices/opi-nova-v1.0.md
+++ b/pages/devices/opi-nova-v1.0.md
@@ -1,14 +1,10 @@
 ---
 layout: page
 returnLink: /pages/devices
+pageTitle: 产品规格数据库
+pageSubTitle: OrangePi Nova v1.0
 ---
 
-<ChildHeader>
-<template #pageTitle>产品规格数据库</template>
-<template #pageSubTitle>OrangePi Nova v1.0</template>
-</ChildHeader>
-
-<div class="body_content">
 
 OrangePi Nova v1.0 是由迅龙软件（香橙派）推出的，基于 2K3000-i 平台设计的 Nano-ITX (120×120mm) 小型主板。
 
@@ -37,11 +33,3 @@ OrangePi Nova v1.0 是由迅龙软件（香橙派）推出的，基于 2K3000-i 
 [![](/public/images/devices/opi-nova-v1.0.thumbnail.webp)](/public/images/devices/opi-nova-v1.0.webp)
 来源：白铭骢、Xi Ruoyao
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/guides.md
+++ b/pages/guides.md
@@ -2,14 +2,9 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 玩机及踩坑指南
+pageSubTitle: 大家都说，龙芯有点创——
 ---
-
-<ChildHeader>
-    <template #pageTitle>玩机及踩坑指南</template>
-    <template #pageSubTitle>大家都说，龙芯有点创——</template>
-</ChildHeader>
-
-<div class="body_content">
 
 大家都说，龙芯有点创—— 这绝非空穴来风！本指南将带您买好、玩好、用好龙芯。
 
@@ -23,11 +18,3 @@ returnLink: /
 - [常见问题集：笔记本平台](/pages/guides/errata-laptop)
 - [常见问题集：开发板](/pages/guides/errata-evb)
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/guides/errata-desktop-and-server.md
+++ b/pages/guides/errata-desktop-and-server.md
@@ -1,14 +1,9 @@
 ---
 layout: page
 returnLink: /pages/guides
+pageTitle: 常见问题集
+pageSubTitle: 各类桌面平台已知问题
 ---
-
-<ChildHeader>
-    <template #pageTitle>常见问题集</template>
-    <template #pageSubTitle>各类桌面平台已知问题</template>
-</ChildHeader>
-
-<div class="body_content">
 
 # 7A 桥片稳定性问题
 
@@ -24,11 +19,3 @@ returnLink: /pages/guides
 
 根据龙芯中科工程师的调查，这是龙芯 7A2000 桥片的[一个硬件缺陷导致的](https://github.com/torvalds/linux/commit/bcb60d438547355b8f9ad48645909139b64d3482)。该问题已在 Linux 内核 6.15-rc1 或更高版本被规避，使用 6.6 内核的商用 ABI 2.0 发行版及使用 4.19 内核的 ABI 1.0 系统均包含此问题的规避。
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/guides/errata-evb.md
+++ b/pages/guides/errata-evb.md
@@ -1,22 +1,9 @@
 ---
 layout: page
 returnLink: /pages/guides
+pageTitle: 常见问题集
+pageSubTitle: 各类开发板已知问题
 ---
-
-<ChildHeader>
-    <template #pageTitle>常见问题集</template>
-    <template #pageSubTitle>各类开发板已知问题</template>
-</ChildHeader>
-
-<div class="body_content">
 
 暂无记录。
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/guides/errata-laptop.md
+++ b/pages/guides/errata-laptop.md
@@ -1,14 +1,9 @@
 ---
 layout: page
 returnLink: /pages/guides
+pageTitle: 常见问题集
+pageSubTitle: 各类笔记本平台已知问题
 ---
-
-<ChildHeader>
-    <template #pageTitle>常见问题集</template>
-    <template #pageSubTitle>各类笔记本平台已知问题</template>
-</ChildHeader>
-
-<div class="body_content">
 
 # ABI 2.0 系统下触摸板无法使用
 
@@ -37,11 +32,3 @@ Linux 内核方面，需要为 7A2000 GPIO 驱动[增加中断支持](https://gi
 
 使用搭载上游内核的 ABI 2.0（“新世界”）Linux 发行版无法启用处理器调频功能，这是因为上游内核尚未实现市售设备使用的 SMCv1 接口功能导致的。目前社区开发者[梓瑶](https://github.com/ziyao233)已提交[初版补丁](https://lore.kernel.org/loongarch/20250623123321.5622-1-ziyao@disroot.org/)，但在测试过程中仍发现有不稳定现象。
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/guides/out-of-the-box.md
+++ b/pages/guides/out-of-the-box.md
@@ -1,14 +1,9 @@
 ---
 layout: page
 returnLink: /pages/guides
+pageTitle: 在亮机前
+pageSubTitle: 从购买入坑，如何获得良好体验？
 ---
-
-<ChildHeader>
-    <template #pageTitle>在亮机前</template>
-    <template #pageSubTitle>从购买入坑，如何获得良好体验？</template>
-</ChildHeader>
-
-<div class="body_content">
 
 # 开箱上手：还得买些啥？
 
@@ -60,11 +55,3 @@ returnLink: /pages/guides
 
 另外还有统信 UOS、银河麒麟、中科方德、openEuler 及开放鸿蒙等商用系统可供选用。
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/intro.md
+++ b/pages/intro.md
@@ -2,14 +2,10 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 走向新世界！
+pageSubTitle: 欢迎来到 x86 和 ARM 远山之外的龙芯世界
 ---
 
-<ChildHeader>
-<template #pageTitle>走向新世界！</template>
-<template #pageSubTitle>欢迎来到 x86 和 ARM 远山之外的龙芯世界</template>
-</ChildHeader>
-
-<div class="body_content">
 
 龙芯是我国自主芯片产业的一颗明星——自 2001 年诞生于中科院计算所起，龙芯经过多次迭代，逐渐在性能方面追赶上了国际先进水平；2021 年，龙芯更是推出了自主研发的龙架构 (LoongArch) 指令集体系架构，立志建成自 x86 和 ARM 后的第三大指令集软硬件生态。如今，龙芯已走入公开市场，各类龙芯台式机、笔记本、服务器和开发板也越来越容易买到，成为了不少社区爱好者和开发者们手中的玩物——甚至有一些朋友们已经开始使用龙芯作为生产力工具。
 
@@ -109,11 +105,4 @@ returnLink: /
 - [Loong 1-2-3 站点“龙芯芯片参数”数据库](https://loong123.cn/chips/)
 - [龙芯中科官方网站“芯片产品”板块](https://www.loongson.cn/product/channel)
 
-</div>
 
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/jobs.md
+++ b/pages/jobs.md
@@ -2,14 +2,10 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 悬赏与实习机会
+pageSubTitle: 用爱发电，也许发财 ( ͡° ͜ʖ ͡°)
 ---
 
-<ChildHeader>
-<template #pageTitle>悬赏与实习机会</template>
-<template #pageSubTitle>用爱发电，也许发财 ( ͡° ͜ʖ ͡°)</template>
-</ChildHeader>
-
-<div class="body_content">
 
 # 社区悬赏项目
 
@@ -19,11 +15,3 @@ returnLink: /
 
 奖品：龙芯笔记本一台
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/support.md
+++ b/pages/support.md
@@ -2,24 +2,12 @@
 layout: page
 # 返回首页
 returnLink: /
+pageTitle: 社区支持中心
+pageSubTitle: 获取板卡、整机产品的说明书及固件更新等支持信息
 ---
 
-<ChildHeader>
-<template #pageTitle>社区支持中心</template>
-<template #pageSubTitle>获取板卡、整机产品的说明书及固件更新等支持信息</template>
-</ChildHeader>
-
-<div class="body_content">
 
 ::: warning
 本页面正在施工，敬请期待
 :::
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>

--- a/pages/tpl.md
+++ b/pages/tpl.md
@@ -2,14 +2,10 @@
 layout: page
 # 返回首页，想返回哪张页面，就在下面填写相对链接
 returnLink: /
+pageTitle:  # 大标题
+pageSubTitle: # 小标题
 ---
 
-<ChildHeader>
-<template #pageTitle>子页面主标题</template>
-<template #pageSubTitle>这里是副标题</template>
-</ChildHeader>
-
-<div class="body_content">
 
 # 这里是标题
 
@@ -48,11 +44,3 @@ This is a dangerous warning.
 This is a details block.
 :::
 
-</div>
-
-<ChildFooter />
-
-<script setup>
-import ChildHeader from '/components/ChildHeader.vue'
-import ChildFooter from '/components/ChildFooter.vue'
-</script>


### PR DESCRIPTION
- 移除 Markdown 文件内的所有非必要的 HTML 样式和 Vue 组件调用，主副标题改为在 frontmatter 中填写，以降低其他贡献者对文档的疑惑 (应该没有人需要在大标题上加其他样式吧)
- 底部样式改为通用组件，对于首页只需额外加载部分样式即可