### PR TITLE
fix(chips): fix GPU model of 7A1000 and 2K1000

### DIFF
--- a/data/chips/chipset/7A1000/7A1000-i.yml
+++ b/data/chips/chipset/7A1000/7A1000-i.yml
@@ -12,7 +12,7 @@ chipset:
   
 gpu:
   available: true
-  name: "LG100"
+  name: "Vivante GC1000"
 
 exp:
   io_name: "PCI Express"

--- a/data/chips/chipset/7A1000/7A1000.yml
+++ b/data/chips/chipset/7A1000/7A1000.yml
@@ -12,7 +12,7 @@ chipset:
   
 gpu:
   available: true
-  name: "LG100"
+  name: "Vivante GC1000"
 
 exp:
   io_name: "PCI Express"

--- a/data/chips/cpu/2k1000/2K1000LA-i.yml
+++ b/data/chips/cpu/2k1000/2K1000LA-i.yml
@@ -22,7 +22,7 @@ cpu:
 
 gpu:
   available: true
-  name: "unknown (OpenVG support)"
+  name: "Vivante GC1000"
   
 memory:
   max: "1 GiB"

--- a/data/chips/cpu/2k1000/2K1000LA.yml
+++ b/data/chips/cpu/2k1000/2K1000LA.yml
@@ -22,7 +22,7 @@ cpu:
 
 gpu:
   available: true
-  name: "unknown (OpenVG support)"
+  name: "Vivante GC1000"
   
 memory:
   max: "1 GiB"


### PR DESCRIPTION
Per various data source, their GPU model is Vivante GC1000.

Link: https://admin.pci-ids.ucw.cz/read/PC/0014/7a05
Link: https://admin.pci-ids.ucw.cz/read/PC/0014/7a15
Link: https://lore.kernel.org/dri-devel/20240206172759.421737-8-sui.jingfeng@linux.dev/