### PR TITLE
fix(chips): fix GPU model of 2K2000

### DIFF
--- a/data/chips/cpu/2k2000/2K2000-i.yml
+++ b/data/chips/cpu/2k2000/2K2000-i.yml
@@ -22,7 +22,7 @@ cpu:
 
 gpu:
   available: true
-  name: "unknown"
+  name: "LG120"
 
 memory:
   max: "32 GiB"

--- a/data/chips/cpu/2k2000/2K2000.yml
+++ b/data/chips/cpu/2k2000/2K2000.yml
@@ -22,7 +22,7 @@ cpu:
 
 gpu:
   available: true
-  name: "unknown"
+  name: "LG120"
 
 memory:
   max: "32 GiB"


### PR DESCRIPTION
A Loongson news entry says the GPU model is LG120, and on a 2K2000-based laptop the Loongnix 25 kernel driver reports "LG100 series LG120" as well.

Link: https://www.loongson.cn/news/show?id=600