### PR TITLE
fix(devices/kaitian-n60d-g1d): remove a duplicated subtitle

### DIFF
--- a/data/devices/kaitian-n60d-g1d/content.zh.md
+++ b/data/devices/kaitian-n60d-g1d/content.zh.md
@@ -27,8 +27,6 @@
 
 <template #known-issues>
 
-### ABI2.0 系统下触摸板无法使用
-
 <!--@include: @parts/known-issues/touchpad-err-in-abi2.md -->
 
 <!--@include: @parts/known-issues/loonggpu-err-in-abi2.md -->


### PR DESCRIPTION
Remove a duplicated subtitle in `content.zh.md` of kaitian-n60d-g1d.