### PR TITLE
fix: update firmware repository URL (file.loongfans.cn → fw.loongfans.cn)

### DIFF
--- a/data/downloads/uefi-fw-ctcisz-3b6000m-nuc-v0.45_1209a_1.yml
+++ b/data/downloads/uefi-fw-ctcisz-3b6000m-nuc-v0.45_1209a_1.yml
@@ -3,7 +3,7 @@ version: "v0.45_1209a_1"
 size: 8388608
 date: "2026-03-07"
 sha256: "37b8b8ff47b80fbc67280d6fb03b4709fda7eb0cd10c4eee7a8a492240f7703b"
-url: "https://file.loongfans.cn/ctcisz-3b6000m-nuc/uefi-fw-ctcisz-3b6000m-nuc-v0.45_1209a_1.fd"
+url: "https://fw.loongfans.cn/ctcisz-3b6000m-nuc/uefi-fw-ctcisz-3b6000m-nuc-v0.45_1209a_1.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0343_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0343_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0343_stable202511_dbg"
 size: 6291456
 date: "2026-01-07"
 sha256: "2fae03cb22673398c59d7f2c5b5ad62bf50dbbb42eaa06c2a3cf0bbf0c3f2593"
-url: "https://file.loongfans.cn/ac612a0-v1.0/EDK2025_AC612A0-V1.0_V5.0.0343_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/ac612a0-v1.0/EDK2025_AC612A0-V1.0_V5.0.0343_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0343_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0343_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0343_stable202511_rel"
 size: 6291456
 date: "2026-01-07"
 sha256: "021a22173dcea9f001de5fa876b3e32897d119743dcdaea8d776822fc27678d5"
-url: "https://file.loongfans.cn/ac612a0-v1.0/EDK2025_AC612A0-V1.0_V5.0.0343_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/ac612a0-v1.0/EDK2025_AC612A0-V1.0_V5.0.0343_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0428_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0428_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_dbg"
 size: 6291456
 date: "2026-04-02"
 sha256: "cfadcbfadb48f2b94d5d7fce705d1c72f6eb5a49f2fe339930dca94128a5ff92"
-url: "https://file.loongfans.cn/ac612a0-v1.0/EDK2505_AC612A0-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/ac612a0-v1.0/EDK2505_AC612A0-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0428_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-ac612a0-v1.0-v5.0.0428_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_rel"
 size: 6291456
 date: "2026-04-02"
 sha256: "ef77dfea54c8371a97db7433cab8724414e3d2771c1cbbb3acdb18023fdfadb4"
-url: "https://file.loongfans.cn/ac612a0-v1.0/EDK2505_AC612A0-V1.0_General_V5.0.0428-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/ac612a0-v1.0/EDK2505_AC612A0-V1.0_General_V5.0.0428-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-x2k30b0-v1.0-v5.0.0431_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-x2k30b0-v1.0-v5.0.0431_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0431_stable202602_dbg"
 size: 8388608
 date: "2026-04-02"
 sha256: "64fe7e737e7bdf2d31f5c61cd36248f650cb9cfbcaabc69abb963656a47056a9"
-url: "https://file.loongfans.cn/x2k30b0-v1.0/EDK2505_X2K30B0-V1.0_General_V5.0.0431-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/x2k30b0-v1.0/EDK2505_X2K30B0-V1.0_General_V5.0.0431-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-x2k30b0-v1.0-v5.0.0431_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-x2k30b0-v1.0-v5.0.0431_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0431_stable202602_rel"
 size: 8388608
 date: "2026-04-02"
 sha256: "76bdca394c46147025c18056045a136e78c3335bb71eb9ef3d969b54d23c5ea9"
-url: "https://file.loongfans.cn/x2k30b0-v1.0/EDK2505_X2K30B0-V1.0_General_V5.0.0431-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/x2k30b0-v1.0/EDK2505_X2K30B0-V1.0_General_V5.0.0431-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2311dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2311dbg.yml
@@ -3,5 +3,5 @@ version: "V4.0.05634_prestable2311dbg"
 size: 4194304
 date: "2023-11-29"
 sha256: "c8366b5c56675e048df9ef1e0227bf57d0e4efdcc7068798410c18a9277100c3"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2311dbg.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2311dbg.fd"
 debug: true

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2311rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2311rel.yml
@@ -3,4 +3,4 @@ version: "V4.0.05634_prestable2311rel"
 size: 4194304
 date: "2023-11-29"
 sha256: "c8366b5c56675e048df9ef1e0227bf57d0e4efdcc7068798410c18a9277100c3"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2311rel.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2311rel.fd"

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2402_0325dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2402_0325dbg.yml
@@ -3,5 +3,5 @@ version: "V4.0.05634_prestable2402_0325dbg"
 size: 4194304
 date: "2024-02-29"
 sha256: "50da40f1101974f81ce8d64d907efe6362e3e89183080b3c137561683530a7f2"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2402_0325dbg.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2402_0325dbg.fd"
 debug: true

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2402_0325rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05634_prestable2402_0325rel.yml
@@ -3,4 +3,4 @@ version: "V4.0.05634_prestable2402_0325rel"
 size: 4194304
 date: "2024-02-29"
 sha256: "0ae9de39b02052896dc5d18a4b96cc550ca8af8613c181def39de4b17ff7875d"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2402_0325rel.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05634_prestable2402_0325rel.fd"

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05756_prestable2405_0523dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05756_prestable2405_0523dbg.yml
@@ -3,7 +3,7 @@ version: "V4.0.05756_prestable2405_0523dbg"
 size: 8388608
 date: "2024-05-23"
 sha256: "0aed4e73d01f490f5808f18df0056e0f70e38bd2344c45c30bedb6ca0557c6a1"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05756_prestable2405_0523dbg.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05756_prestable2405_0523dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa61200-v4.0.05756_prestable2405_0523rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v4.0.05756_prestable2405_0523rel.yml
@@ -3,7 +3,7 @@ version: "V4.0.05756_prestable2405_0523rel"
 size: 8388608
 date: "2024-05-23"
 sha256: "e7fac091127d5a759d4c043472f1d6f0838acba7f6efb8da72cccaacedad7e5d"
-url: "https://file.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05756_prestable2405_0523rel.fd"
+url: "https://fw.loongfans.cn/xa61200/UDK2018-3A6000-7A2000_EVB_V4.0.05756_prestable2405_0523rel.fd"
 description:
   zh: |
     新增 YT6801 网卡固件驱动、自定义风扇曲线、快速启动及 TPM 支持等新功能，并修复睡眠时的缓存同步问题，提高可靠性。

--- a/data/downloads/uefi-fw-loongson-xa61200-v5.0.0344_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v5.0.0344_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_dbg"
 size: 8388608
 date: "2026-01-07"
 sha256: "7e8913204aa35ff43e6b84ed3886531b3954a11b0c94c8c46504519a5e6f092d"
-url: "https://file.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_V5.0.0344_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_V5.0.0344_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa61200-v5.0.0344_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v5.0.0344_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_rel"
 size: 8388608
 date: "2026-01-07"
 sha256: "93462a963c6b227bf23a5fef579ed3dcd268d3dcc0c5fa052e5a58b8b73416c1"
-url: "https://file.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_V5.0.0344_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_V5.0.0344_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa61200-v5.0.0428_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v5.0.0428_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_dbg"
 size: 8388608
 date: "2026-04-02"
 sha256: "1cf0f0b4e053c4a3a4a6df656c92d653d38d4a4a3b7e4359948099c56208ac89"
-url: "https://file.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa61200-v5.0.0428_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61200-v5.0.0428_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_rel"
 size: 8388608
 date: "2026-04-02"
 sha256: "75aa09d3492722b4d41096d1465f764b966efd538f610e538777ecbbeae1928f"
-url: "https://file.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_General_V5.0.0428-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/xa61200/EDK2505_XA61200-V1.0_General_V5.0.0428-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0344_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0344_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_dbg"
 size: 8388608
 date: "2026-01-07"
 sha256: "90170bee1e0a8d978c94dd2138f7b164c1c230228654b284a6b34ea0efd8b18f"
-url: "https://file.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_V5.0.0344_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_V5.0.0344_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0344_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0344_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_rel"
 size: 8388608
 date: "2026-01-07"
 sha256: "4473366a2079b26302ef53112deab1e44ac5a5bb0f0090216a2da6f031680e52"
-url: "https://file.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_V5.0.0344_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_V5.0.0344_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0428_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0428_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_dbg"
 size: 8388608
 date: "2026-04-02"
 sha256: "ac317d4415103ff093866898d840d0fd918f4f09479ccf3045583b0986eeb9fa"
-url: "https://file.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0428_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa61201-v1.0-v5.0.0428_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_rel"
 size: 8388608
 date: "2026-04-02"
 sha256: "bec68e9497413d5ed2b414b03266a3af6798a50cfe97ba2f0e295a2b4d82e052"
-url: "https://file.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_General_V5.0.0428-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/xa61201-v1.0/EDK2505_XA61201-V1.0_General_V5.0.0428-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-prestable2405rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-prestable2405rel.yml
@@ -3,4 +3,4 @@ version: "prestable2405rel"
 size: 8388608
 date: "2024-05-25"
 sha256: "6862745ef05a7a7f284064d258a36fa9c6bf885eccdebe4a7dba05803c7dd7bc"
-url: "https://file.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_prestable2405rel.fd"
+url: "https://fw.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_prestable2405rel.fd"

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311plldbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311plldbg.yml
@@ -3,7 +3,7 @@ version: "stable2311plldbg"
 size: 4194304
 date: "2024-01-02"
 sha256: "c570d7fb4d405d6e4930e84831ef82538cdc3e2c4c016a2976902660d49e63eb"
-url: "https://file.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311plldbg.fd"
+url: "https://fw.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311plldbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311plldbg_20240525.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311plldbg_20240525.yml
@@ -3,5 +3,5 @@ version: "stable2311plldbg"
 size: 8388608
 date: "2024-05-25"
 sha256: "242f3b2b04de64a863e3bdc429339ca8736eb9437ced166abf3839b72982c233"
-url: "https://file.loongfans.cn/xa61200-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311plldbg.fd"
+url: "https://fw.loongfans.cn/xa61200-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311plldbg.fd"
 debug: true

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311pllrel.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-stable2311pllrel.yml
@@ -3,7 +3,7 @@ version: "stable2311pllrel"
 size: 4194304
 date: "2024-01-02"
 sha256: "6862745ef05a7a7f284064d258a36fa9c6bf885eccdebe4a7dba05803c7dd7bc"
-url: "https://file.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311pllrel.fd"
+url: "https://fw.loongfans.cn/xa612a0-v1.0/UDK2018-3A6000-7A2000_XA612A0_stable2311pllrel.fd"
 description:
   zh: |
     新增 GPU 仿真开关

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-v5.0.0344_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-v5.0.0344_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_dbg"
 size: 8388608
 date: "2026-01-07"
 sha256: "8f75aca6bcbac86bd9f678fb4b7de276d7e8808973f6da66d70b74e0e80b5c95"
-url: "https://file.loongfans.cn/xa612a0-v1.0/EDK2505_XA612A0-V1.0_V5.0.0344_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/xa612a0-v1.0/EDK2505_XA612A0-V1.0_V5.0.0344_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa612a0-v1.0-v5.0.0344_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa612a0-v1.0-v5.0.0344_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_rel"
 size: 8388608
 date: "2026-01-07"
 sha256: "5bebaec30b8933f9a0c65b38ac16a08b2ba206f4d2cfd80f6bb0846a00655665"
-url: "https://file.loongfans.cn/xa612a0-v1.0/EDK2505_XA612A0-V1.0_V5.0.0344_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/xa612a0-v1.0/EDK2505_XA612A0-V1.0_V5.0.0344_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0344_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0344_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_dbg"
 size: 8388608
 date: "2026-01-07"
 sha256: "746de0cd6e30229f06e6708392aa17f75d03e0b3d2ddb4b9a2ce538cbbfe5e36"
-url: "https://file.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_V5.0.0344_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_V5.0.0344_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0344_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0344_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0344_stable202511_rel"
 size: 8388608
 date: "2026-01-07"
 sha256: "9b66cf320f66dde63ec1919698e4963862033c8f0c2fd6569c1125680e1d539e"
-url: "https://file.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_V5.0.0344_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_V5.0.0344_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0428_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0428_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_dbg"
 size: 8388608
 date: "2026-04-02"
 sha256: "01fb17a4fd89fc5b5bac21551419c1431db71ac44587bd78561687f34fce6fe3"
-url: "https://file.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_General_V5.0.0428-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0428_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xa612b0-v1.0-v5.0.0428_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0428_stable202602_rel"
 size: 8388608
 date: "2026-04-02"
 sha256: "1949d9fe7ad2996d77ea8578865a5183a0bc62fa272f81177049fff05f9de976"
-url: "https://file.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_General_V5.0.0428-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/xa612b0-v1.0/EDK2505_XA612B0-V1.0_General_V5.0.0428-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0345_stable202511_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0345_stable202511_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.2_V5.0.0345_stable202511_dbg"
 size: 6291456
 date: "2026-01-07"
 sha256: "c17a7848cd002564cda47eb4a0ded99605301c31e9f828895b0a27542940a0f0"
-url: "https://file.loongfans.cn/xb612b0-v1.2/EDK2025_XB612B0-V1.2_V5.0.0345_stable202511_dbg.fd"
+url: "https://fw.loongfans.cn/xb612b0-v1.2/EDK2025_XB612B0-V1.2_V5.0.0345_stable202511_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0345_stable202511_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0345_stable202511_rel.yml
@@ -3,7 +3,7 @@ version: "V1.2_V5.0.0345_stable202511_rel"
 size: 6291456
 date: "2026-01-07"
 sha256: "38ede1c5710c072d642853d26e30bb2a281c1f36fa588a017780324f71fe6a79"
-url: "https://file.loongfans.cn/xb612b0-v1.2/EDK2025_XB612B0-V1.2_V5.0.0345_stable202511_rel.fd"
+url: "https://fw.loongfans.cn/xb612b0-v1.2/EDK2025_XB612B0-V1.2_V5.0.0345_stable202511_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2511 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0431_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0431_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.2_V5.0.0431_stable202602_dbg"
 size: 6291456
 date: "2026-04-02"
 sha256: "8f586e5f0d981dfde21fb37f48ff5778e5940e199980562336073741d858a62f"
-url: "https://file.loongfans.cn/xb612b0-v1.2/EDK2505_XB612B0-V1.2_General_V5.0.0431-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/xb612b0-v1.2/EDK2505_XB612B0-V1.2_General_V5.0.0431-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0431_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xb612b0-v1.2-v5.0.0431_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.2_V5.0.0431_stable202602_rel"
 size: 6291456
 date: "2026-04-02"
 sha256: "41b00efd0d68517fdd0e6a04a5d352174f94ffe1861cc11a8a60a80faf53fc39"
-url: "https://file.loongfans.cn/xb612b0-v1.2/EDK2505_XB612B0-V1.2_General_V5.0.0431-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/xb612b0-v1.2/EDK2505_XB612B0-V1.2_General_V5.0.0431-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-loongson-xb6mxc0-v1.0-v5.0.0431_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-loongson-xb6mxc0-v1.0-v5.0.0431_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0431_stable202602_dbg"
 size: 8388608
 date: "2026-04-02"
 sha256: "bb7d101ffb826d62d44606ecbe4c60e60ea35791ebd59cc7ce962504d4d7bb7a"
-url: "https://file.loongfans.cn/xb6mxc0-v1.0/EDK2505_XB6MXC0-V1.0_General_V5.0.0431-Stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/xb6mxc0-v1.0/EDK2505_XB6MXC0-V1.0_General_V5.0.0431-Stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-loongson-xb6mxc0-v1.0-v5.0.0431_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-loongson-xb6mxc0-v1.0-v5.0.0431_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.0_V5.0.0431_stable202602_rel"
 size: 8388608
 date: "2026-04-02"
 sha256: "074db611bd6ee2a39d5c933992a7b43920d97839564edf17662c22b438819514"
-url: "https://file.loongfans.cn/xb6mxc0-v1.0/EDK2505_XB6MXC0-V1.0_General_V5.0.0431-Stable202602_rel.fd"
+url: "https://fw.loongfans.cn/xb6mxc0-v1.0/EDK2505_XB6MXC0-V1.0_General_V5.0.0431-Stable202602_rel.fd"
 description:
   zh: |
     本次主要基于 RefCode Stable2602 基线更新，详细更新说明按照流程需要查阅代码发布说明

--- a/data/downloads/uefi-fw-orangepi-nova-v1.1-v5.0.0431_stable202602_dbg.yml
+++ b/data/downloads/uefi-fw-orangepi-nova-v1.1-v5.0.0431_stable202602_dbg.yml
@@ -3,7 +3,7 @@ version: "V1.1_V5.0.0431-stable202602_dbg"
 size: 8388608
 date: "2026-05-08"
 sha256: "eae9ddc55257a5c8030535427e90dc9440595addf19289f7b5d2e2f13e23d911"
-url: "https://file.loongfans.cn/opi-nova-v1.1/EDK2505_OrangePi-Nova-V1.1_V5.0.0431-stable202602_dbg.fd"
+url: "https://fw.loongfans.cn/opi-nova-v1.1/EDK2505_OrangePi-Nova-V1.1_V5.0.0431-stable202602_dbg.fd"
 debug: true
 description:
   zh: |

--- a/data/downloads/uefi-fw-orangepi-nova-v1.1-v5.0.0431_stable202602_rel.yml
+++ b/data/downloads/uefi-fw-orangepi-nova-v1.1-v5.0.0431_stable202602_rel.yml
@@ -3,7 +3,7 @@ version: "V1.1_V5.0.0431-stable202602_rel"
 size: 8388608
 date: "2026-05-08"
 sha256: "01eee99685951c33d890769a91d00b775e4df410917bf409856f5c51052bf275"
-url: "https://file.loongfans.cn/opi-nova-v1.1/EDK2505_OrangePi-Nova-V1.1_V5.0.0431-stable202602_rel.fd"
+url: "https://fw.loongfans.cn/opi-nova-v1.1/EDK2505_OrangePi-Nova-V1.1_V5.0.0431-stable202602_rel.fd"
 description:
   zh: |
     - 本版包含上游 V5.0.0341-stable202602（即 202602 基线）中包含的所有修复，其中较为重要的有：

--- a/docs/design-download-resources.md
+++ b/docs/design-download-resources.md
@@ -74,7 +74,7 @@ version: "V1.0_V5.0.0343_stable202511_rel"
 size: 6291456                          # 字节
 date: "2026-01-07"                     # YYYY-MM-DD
 sha256: "021a22173dcea9f001de5fa876b3e32897d119743dcdaea8d776822fc27678d5"
-url: "https://file.loongfans.cn/..."
+url: "https://fw.loongfans.cn/..."
 debug: false
 description:
   zh: |


### PR DESCRIPTION
## Domain Migration Notice

The firmware download subdomain has been migrated from `file.loongfans.cn` to `fw.loongfans.cn`.

**Reason:** The `file` subdomain has been repurposed for other planned services.

**Changes:**
- Firmware download URLs now use `fw.loongfans.cn`
- `firmware.loongfans.cn` has been configured with redirects to the new domain
- All existing links referencing `file.loongfans.cn` for firmware downloads should be updated

**Impact:** Users accessing firmware downloads through the old domain will be automatically redirected to the new domain.