### PR TITLE
doc: fix 3B6000M/4 spec

### DIFF
--- a/data/chips/cpu/2k3000/3B6000M-4.yml
+++ b/data/chips/cpu/2k3000/3B6000M-4.yml
@@ -23,8 +23,8 @@ cpu:
   tdp: "N/A"
 
 gpu:
-  available: true
-  name: "LG200"
+  available: false
+  name: "N/A"
 
 memory:
   max: "32 GiB (DDR4) / 16 GiB (LPDDR4)"


### PR DESCRIPTION
It has been confirmed that the 3B6000M/4 model does not include the LG200 GPU and supports only DC.