### PR TITLE
OS: update URL to Lierfang's Proxmox repos on Github

### DIFF
--- a/data/os/linux/pve.yml
+++ b/data/os/linux/pve.yml
@@ -1,6 +1,6 @@
 name:
   en: "Proxmox VE"
-href: "https://www.lierfang.com//#/open/third"
+href: "https://github.com/pve-loong64-port"
 # https://www.proxmox.com/en/about/company-details/media-kit
 image: "/images/os/proxmox.svg"
 description:


### PR DESCRIPTION
As at least over here the current link URL https://www.lierfang.com//#/open/third results in an empty page, I suggest to change the link URL to Lierfang's repos on Github https://github.com/pve-loong64-port in the meantime.